### PR TITLE
Create jitpack.yml

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17


### PR DESCRIPTION
This is a _very_ small change which allows fxthemes to be used through jitpack. I know that it's available through maven central, but that version is out of date, and as far as I'm aware there's no downside to supporting both repositories.