### PR TITLE
Fixed detecting Windows 11 and wrong class casting

### DIFF
--- a/FXThemes/src/main/java/com/pixelduke/window/ThemeWindowManagerFactory.java
+++ b/FXThemes/src/main/java/com/pixelduke/window/ThemeWindowManagerFactory.java
@@ -27,7 +27,6 @@ public abstract class ThemeWindowManagerFactory {
                 break;
         }
 
-        System.out.println("Warning: Unsupported Window Operating System");
-        return null;
+        throw new RuntimeException("Unsupported Window Operating System");
     }
 }

--- a/FXThemes/src/main/java/com/pixelduke/window/ThemeWindowManagerFactory.java
+++ b/FXThemes/src/main/java/com/pixelduke/window/ThemeWindowManagerFactory.java
@@ -1,21 +1,19 @@
 package com.pixelduke.window;
 
 import com.sun.jna.Platform;
-import javafx.stage.Window;
 
 public abstract class ThemeWindowManagerFactory {
-    
+
     public static ThemeWindowManager create() {
         String osName = System.getProperty("os.name");
-        int majorVersion = getMajorVersion();
-        
+
         // Check which operating system and version we're running and return appropriate ThemeWindowManager
-        switch(Platform.getOSType()){
+        switch (Platform.getOSType()) {
             case Platform.WINDOWS:
-                switch(majorVersion){
-                    case 10:
+                switch (osName) {
+                    case "Windows 10":
                         return new Win10ThemeWindowManager();
-                    case 11:
+                    case "Windows 11":
                         return new Win11ThemeWindowManager();
                     default:
                         break;
@@ -28,23 +26,8 @@ public abstract class ThemeWindowManagerFactory {
             default:
                 break;
         }
-        
-        return new ThemeWindowManager(){
-            public void setDarkModeForWindowFrame(Window window, boolean darkMode){
-                System.out.println("Warning: Unsupported Window Operating System");
-            }
-        };
-    }
 
-    private static int getMajorVersion(){
-        int version = -1;
-        
-        try{
-            version = Integer.parseInt(System.getProperty("os.version").split("\\.")[0]);
-        }catch (Exception e){
-            System.err.println("Failed to obtain the major version of the Operating System!");
-            e.printStackTrace();
-        }
-        return version;
+        System.out.println("Warning: Unsupported Window Operating System");
+        return null;
     }
 }


### PR DESCRIPTION
The changes merged from PR #6 are incorrect and are breaking the library. It introduced **two** bugs.

First, Windows 11 is no longer detected. The switch statement is getting a value from the `os.version` property, but we must remember that Windows 11 was essentially a Windows 10 refresh. This property returns **10** instead of **11** because of that. If we look into _commons-lang3_ to class **SystemUtils**, we can see that field [`IS_OS_WINDOWS_11`](https://github.com/apache/commons-lang/blob/ff66cce0ca10046727e594e0beeed7924dfc7a41/src/main/java/org/apache/commons/lang3/SystemUtils.java#L1817-L1836) is also a result of an `os.name` match.

Secondly, returning an anonymous method may seem useful, but it is not possible with the current library design. If we encounter a situation where none of the system is supported and we try to cast the return into a specific **ThemeWindowManager**, it will throw a **ClassCastException**. It can be casted to **ThemeWindowManager**, but not to the created anonymous **ThemeWindowManagerFactory$1**. Therefore, I suggest making the method Nullable or considering using Optionals.