### PR TITLE
resolve tkStage is null

### DIFF
--- a/FXThemes/src/main/java/com/pixelduke/window/Win11ThemeWindowManager.java
+++ b/FXThemes/src/main/java/com/pixelduke/window/Win11ThemeWindowManager.java
@@ -21,11 +21,19 @@ public class Win11ThemeWindowManager implements ThemeWindowManager {
     }
 
     public void setDarkModeForWindowFrame(Window window, boolean darkMode) {
-        DWM.setWindowAttribute(
+        if (window.isShowing()) {
+            DWM.setWindowAttribute(
+                    WindowUtils.getNativeHandleOfStage(window),
+                    DWMA_WINDOW_ATTRIBUTE.DWMWA_USE_IMMERSIVE_DARK_MODE.getValue(),
+                    darkMode
+            );
+            return;
+        }
+        window.setOnShown(event -> DWM.setWindowAttribute(
                 WindowUtils.getNativeHandleOfStage(window),
                 DWMA_WINDOW_ATTRIBUTE.DWMWA_USE_IMMERSIVE_DARK_MODE.getValue(),
                 darkMode
-        );
+        ));
     }
 
     /**     BELOW STILL NOT WORKING


### PR DESCRIPTION
Mehod setDarkModeForWindowFrame can take effect after window is shown, even not showing.
If a child window want to showAndWait, theme.setScene will NullPointException cause by tkStage is null.
You can see the error in [this](https://github.com/dukke/Transit/blob/main/transit-samples/src/main/java/com/pixelduke/samples/transit/DialogSample.java).


Also, I don't know if it's intentional here?
![image](https://github.com/user-attachments/assets/b16b7534-de81-488f-ae82-c72d72adb322)
